### PR TITLE
[BACKLOG-33162] Set a predictable id on scm source

### DIFF
--- a/src/main/groovy/org/hitachivantara/ci/plugins/workflow/steps/CreateJobStep.groovy
+++ b/src/main/groovy/org/hitachivantara/ci/plugins/workflow/steps/CreateJobStep.groovy
@@ -141,6 +141,7 @@ class CreateJobStep extends Step implements Serializable {
 
       ScmConfig scmConfig = step.scmConfig
       GitHubSCMSource scmSource = new GitHubSCMSource(scmConfig.organization, scmConfig.repository)
+      scmSource.setId(scmConfig.organization + '/' + scmConfig.repository)
       scmSource.setCredentialsId(scmConfig.credentials)
 
       List scmTraits = [


### PR DESCRIPTION
@pentaho/x-wing 